### PR TITLE
allow skipping of the directory-maven-plugin by putting the phase int…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <version.compiler.plugin>3.11.0</version.compiler.plugin>
     <version.dependency.plugin>3.5.0</version.dependency.plugin>
     <version.deploy.plugin>3.1.1</version.deploy.plugin>
-    <version.directory.plugin>0.3.1</version.directory.plugin>
+    <version.directory.plugin>1.0</version.directory.plugin>
     <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
     <version.enforcer.extra.rules>1.6.1</version.enforcer.extra.rules>
     <version.failsafe.plugin>3.0.0</version.failsafe.plugin>
@@ -75,6 +75,7 @@
     <version.source.plugin>3.2.1</version.source.plugin>
     <version.surefire.plugin>3.0.0</version.surefire.plugin>
     <version.versions.plugin>2.15.0</version.versions.plugin>
+    <phase.directory.plugin>initialize</phase.directory.plugin>
   </properties>
 
   <licenses>
@@ -244,7 +245,7 @@
             <goals>
               <goal>highest-basedir</goal>
             </goals>
-            <phase>initialize</phase>
+            <phase>${phase.directory.plugin}</phase>
             <configuration>
               <property>rootdir</property>
             </configuration>


### PR DESCRIPTION
…o a property

The problem with this plugin is that it does not allow using the `-pl` parameter. It will fail in such cases.