### PR TITLE
force Git commit date timezone to UTC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,7 @@
               <generateGitPropertiesFilename>${project.build.directory}/git.properties
               </generateGitPropertiesFilename>
               <dateFormat>yyyy-MM-dd'T'HH:mm:ssXXX</dateFormat>
+              <dateFormatTimeZone>UTC</dateFormatTimeZone>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
makes it independent from user timezone

the release is already done with UTC, then it won't change anything for releases
but on day to day activities, with build done locally, this small variation is hidden